### PR TITLE
Update link to be absolute, else it looks for a file within the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ provide it with a Personal Key. These keys begin with `nvapi-`.
     prompted to, then register for a new account and sign in.
     
     > **HINT** You can find this tool by logging into
-    > [ngc.nvidia.com](ngc.nvidia.com), expanding your profile menu on
+    > [ngc.nvidia.com](https://ngc.nvidia.com), expanding your profile menu on
     > the top right, selecting *Setup*, and then selecting *Generate
     > Personal Key*.
 


### PR DESCRIPTION
**This PR is tiny update to simply change a failing relative link to be absolute.**

Thanks for the great intro! We're using this as a reference for a multi-container setup (also understanding that another way of doing this is coming soon). In any case, found a minor issue that causes a clickable link to fail for the NGC catalogue.

In browser the markdown style link to the NGC is interpreted as a regular file... so clicking it in some conditions takes you to a non-existent file:

![image](https://github.com/user-attachments/assets/f8303796-bf38-443f-a773-fb11bcb78706)


